### PR TITLE
mis-spelling "TWILIO_ACCOUT_SID to TWILIO_ACCOUNT_SID"

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -2,7 +2,7 @@ const express = require('express');
 const bodyParser = require('body-parser');
 const pino = require('express-pino-logger')();
 const client = require('twilio')(
-  process.env.TWILIO_ACCOUT_SID,
+  process.env.TWILIO_ACCOUNT_SID,
   process.env.TWILIO_AUTH_TOKEN
 );
 


### PR DESCRIPTION
I'm pretty sure there was a mis-spelling.